### PR TITLE
Fixed auth so it works on Windows, too.

### DIFF
--- a/stormpath_cli/auth.py
+++ b/stormpath_cli/auth.py
@@ -66,17 +66,15 @@ def init_auth(args, quiet=True):
                 "authentication.")
         return dict(api_key_file_location=key_file)
 
-    if 'HOME' in environ:
-        key_file = get_config_path('apiKey.properties')
-        if not exists(key_file):
-            key_file = join(environ['HOME'], '.stormpath', 'apiKey.properties')
+    key_file = get_config_path('apiKey.properties')
+    if not exists(key_file) and 'HOME' in environ:
+        key_file = join(environ['HOME'], '.stormpath', 'apiKey.properties')
 
-        if exists(key_file):
-            key_file = realpath(key_file)
-            if not quiet:
-                log.info("Using API Key file %s for authentication." %
-                    key_file)
-            return dict(api_key_file_location=key_file)
+    if exists(key_file):
+        key_file = realpath(key_file)
+        if not quiet:
+            log.info("Using API Key file %s for authentication." % key_file)
+        return dict(api_key_file_location=key_file)
 
     raise ValueError("Unable to discover an existing API Key file path "
         "or API Key environment variable.")

--- a/stormpath_cli/util.py
+++ b/stormpath_cli/util.py
@@ -1,10 +1,19 @@
-from os import environ, makedirs, rename, chmod, unlink
-from os.path import join, dirname, exists
+import sys
+from os import chmod, environ, makedirs, rename, unlink
+from os.path import dirname, exists, join, splitdrive
+
+
+def get_root_path():
+    """Helper function for getting the root path."""
+    drive = splitdrive(sys.executable)[0]
+    if drive:
+        return '%s\\' % drive
+    return '/'
 
 
 def get_config_path(name):
     """Helper function for getting the cli config file path."""
-    sp_root_dir = join(environ.get('HOME', '/'), '.stormpath')
+    sp_root_dir = join(environ.get('HOME', get_root_path()), '.stormpath')
     return join(sp_root_dir, 'cli', name)
 
 
@@ -93,4 +102,3 @@ def properly_support_boolean_values(arguments):
     arguments['--is-default-account-store'] = _txt_to_bool(arguments.get('--is-default-account-store'))
     arguments['--is-default-group-store'] = _txt_to_bool(arguments.get('--is-default-group-store'))
     return arguments
-


### PR DESCRIPTION
CLI tool didn't work on Windows (as reported in #45) because it used hardcoded root ("/"). I fixed this so it tries to get current drive and uses it as root (or uses "/" if system do not use drive specifications).