### PR TITLE
Output one resource at a time if possible.

### DIFF
--- a/stormpath_cli/actions.py
+++ b/stormpath_cli/actions.py
@@ -200,7 +200,8 @@ def list_resources(coll, args):
     if not isinstance(coll, AccountStoreMappingList):
         if q:
             coll = coll.query(**q)
-    return [get_resource_data(r) for r in coll]
+    for r in coll:
+        yield get_resource_data(r)
 
 
 def create_resource(coll, args):

--- a/stormpath_cli/main.py
+++ b/stormpath_cli/main.py
@@ -67,6 +67,7 @@ For -A and -D options, the application and directory can be specified by their
 name or URL.
 """
 
+import types
 from sys import version_info as vi
 
 from docopt import docopt
@@ -161,7 +162,10 @@ def main():
         log.error(str(ex))
         return -1
 
-    if result is not None and (isinstance(result, list) or isinstance(result, dict)):
+    if result is not None and (
+            isinstance(result, list) or
+            isinstance(result, dict) or
+            isinstance(result, types.GeneratorType)):
         output(
             result, show_links=arguments.get('--show-links', False),
             show_headers=arguments.get('--show-headers', False),


### PR DESCRIPTION
Outputting a list of resources will make an API call for every resource in the list (because it will call https://github.com/stormpath/stormpath-cli/blob/develop/stormpath_cli/resources.py#L16 function when listing resources https://github.com/stormpath/stormpath-cli/blob/develop/stormpath_cli/actions.py#L203).

As described in #48, I modified the code to display resources as they come (one by one). I did this using a generator function instead of returning a list and using that function if appropriate (if it needs to output JSON, we need all of resources in one list anyway).