### PR TITLE
--output-json should always override default format

### DIFF
--- a/stormpath_cli/output.py
+++ b/stormpath_cli/output.py
@@ -126,11 +126,10 @@ def _output(data, show_links=False, show_headers=False, output_json=False):
     else:
         data = _show_links(data)
 
-    if stdout.isatty():
-        if output_json:
-            _output_to_tty_json(data)
-        else:
-            _output_to_tty_human_readable(data)
+    if output_json:
+        _output_to_tty_json(data)
+    elif stdout.isatty():
+        _output_to_tty_human_readable(data)
     else:
         _output_tsv(data, show_headers=show_headers)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -108,3 +108,10 @@ class TestOutput(unittest.TestCase):
         output._output.assert_called_with(
             list(generate_data()), output_json=True, show_headers=False,
             show_links=False)
+
+    def test_json_output_when_not_a_tty(self):
+        data = [{'href': 'test', 'description': 'test_description'}]
+        output._output_to_tty_json = MagicMock()
+
+        output._output(data=data, output_json=True)
+        output._output_to_tty_json.assert_called_with(data)


### PR DESCRIPTION
This should fix the bug described in issue #50 .